### PR TITLE
Add git-post-push-compare-url

### DIFF
--- a/bin/git-post-push-compare-url
+++ b/bin/git-post-push-compare-url
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Prints the compare URL of the push you just made.
+#
+# This is tied to repos using the https:// protocol on github.com now for one
+# very good reason: I am lazy. You should be using https:// anyway. We can make
+# this generic for other environments as well at some point. #yolo
+output=
+
+while read line
+do
+  if [[ "$line" != "Done" ]]
+  then
+    echo $line
+    output=$line
+  fi
+done
+
+comparison=$(echo $output | cut -d' ' -f2)
+remote=$(git config --get remote.origin.url)
+
+if [[ -n "$comparison" && $remote == *"https://github.com"* ]]
+then
+  echo "$remote/compare/$comparison"
+fi

--- a/git/aliases.zsh
+++ b/git/aliases.zsh
@@ -9,7 +9,7 @@ fi
 # The rest of my fun git aliases
 alias gl='git pull --prune'
 alias glog="git log --graph --pretty=format:'%Cred%h%Creset %an: %s - %Creset %C(yellow)%d%Creset %Cgreen(%cr)%Creset' --abbrev-commit --date=relative"
-alias gp='git push origin HEAD'
+alias gp='git push origin HEAD --porcelain | git-post-push-compare-url'
 alias gd='git diff'
 alias gc='git commit'
 alias gca='git commit -a'


### PR DESCRIPTION
This is a script that allows us to print the URL of the Compare View for
a particular push.

Git doesn't have a post-push hook because of weird pedantic hand wavery
reasons, so instead I'm tying this into `gp`, which is my alias for
pushing to the remote. The porcelain version of the command is used and
piped to `git-post-push-compare-url`, which simply checks to see if it's
a github.com URL and then prints it to stdout. From there I can
triple-click the line to quickly copy it and paste it elsewhere if I
want. I didn't want to go so far as to pipe it to `open` or something,
although that could be a possibility, too.
